### PR TITLE
Update WINDOWS_MULTIPASS_DEFAULT_ID_RSA for multipass 1.10.0

### DIFF
--- a/local_ssh_config/ssh/_constants.py
+++ b/local_ssh_config/ssh/_constants.py
@@ -6,4 +6,6 @@ SSH_CONFIG_FILE = Path.home() / ".ssh/config"
 
 SSH_CONFIG_INCLUDE_DIRECTIVE = "Include config.d/*"
 
-WINDOWS_MULTIPASS_DEFAULT_ID_RSA = "C:/Windows/System32/config/systemprofile/AppData/Roaming/multipassd/ssh-keys/id_rsa"
+WINDOWS_MULTIPASS_DEFAULT_ID_RSA = (
+    "C:/Windows/ProgramData/Multipass/data/ssh-keys/id_rsa"
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ show_error_codes = true
 
 [tool.poetry]
 name = "local_ssh_config"
-version = "0.4.1"
+version = "0.4.2"
 description = "Quickly update config (ssh files and host file) for your local virtual machines"
 authors = ["Ian Cleary <contact@iancleary.me>"]
 license = "MIT"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,6 @@
 from local_ssh_config import __version__, package_version
 
-current_version = "0.4.1"
+current_version = "0.4.2"
 
 
 def test_package_version() -> None:


### PR DESCRIPTION
## Description

This repository needs to update the `WINDOWS_MULTIPASS_DEFAULT_ID_RSA` per https://github.com/canonical/multipass/issues/913#issuecomment-1183562315 for Multipass >= 1.10.0

The commits in this pull request will do that.

## Related

Relates to https://github.com/canonical/multipass/issues/913#issuecomment-1183562315

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
